### PR TITLE
Add WildFly Swarm Profile

### DIFF
--- a/jjug-resteasy-html/pom.xml
+++ b/jjug-resteasy-html/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.wildfly-swarm>1.0.0.Beta8</version.wildfly-swarm>
     </properties>
 
     <dependencyManagement>
@@ -122,4 +123,30 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>swarm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.wildfly.swarm</groupId>
+                        <artifactId>wildfly-swarm-plugin</artifactId>
+                        <version>${version.wildfly-swarm}</version>
+                        <configuration>
+                            <properties>
+                                <swarm.context.path>${project.artifactId}-${project.version}</swarm.context.path>
+                            </properties>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
package するたびに毎回 -swarm 向けにビルドするのもちょっと遅くなるのであれかなと思い、プロファイルをわけてみました。-swarm 向けにビルドする際は、`mvn clean package -Pswarm` です。

また、-swarm はデフォルトのコンテキストパスは "/" になるため、war で通常のようにデプロイした場合と同じ URL になるよう ${project.artifactId}-${project.version} に置き換えてあります。

これで id 1 - 5, 77, 88, 99 にアクセスしてみましたが、手元では Twitter でおっしゃられてた NoClassDefFoundError は出てません。
